### PR TITLE
Declare explicit macos dependency

### DIFF
--- a/Formula/bicep.rb
+++ b/Formula/bicep.rb
@@ -2,6 +2,7 @@ class Bicep < Formula
   desc "Bicep: next generation template language for Azure Resource Manager (ARM)"
   homepage "https://github.com/Azure/bicep"
   version "0.16.2"
+  depends_on :macos
 
   case
   when OS.mac? && Hardware::CPU.intel?


### PR DESCRIPTION
As suggested in https://github.com/Homebrew/brew/issues/15242#issuecomment-1512634563, this PR declares the bicep formula to depend on macos so that homebrew users on Linux can get a better error message. The syntax used was cribbed from https://github.com/Homebrew/homebrew-core/pull/74530