### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -34,7 +34,7 @@ jobs:
           set -euxo pipefail
 
           result=$(curl -Lf https://github.com/Azure/bicep/releases/download/v${{ steps.get_release_version.outputs.result }}/bicep-osx-x64 | sha256sum | awk '{print $1}')
-          echo "::set-output name=result::$result"
+          echo "result=$result" >> $GITHUB_OUTPUT
 
       - name: Get SHA256 checksum for arm64
         id: get_release_sha256_arm64
@@ -42,7 +42,7 @@ jobs:
           set -euxo pipefail
 
           result=$(curl -Lf https://github.com/Azure/bicep/releases/download/v${{ steps.get_release_version.outputs.result }}/bicep-osx-arm64 | sha256sum | awk '{print $1}')
-          echo "::set-output name=result::$result"
+          echo "result=$result" >> $GITHUB_OUTPUT
 
       - name: Update the Homebrew formula
         run: |


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter`